### PR TITLE
Fix small path bug in the Master implementation

### DIFF
--- a/src/main/java/org/apache/zookeeper/book/Master.java
+++ b/src/main/java/org/apache/zookeeper/book/Master.java
@@ -481,14 +481,15 @@ public class Master implements Watcher, Closeable {
     }
     
     void getAbsentWorkerTasks(String worker){
-        zk.getChildren("/assign/" + worker, false, workerAssignmentCallback, null);
+        zk.getChildren("/assign/" + worker, false, workerAssignmentCallback, worker);
     }
     
     ChildrenCallback workerAssignmentCallback = new ChildrenCallback() {
         public void processResult(int rc, String path, Object ctx, List<String> children){
-            switch (Code.get(rc)) { 
+            String worker = (String) ctx;
+            switch (Code.get(rc)) {
             case CONNECTIONLOSS:
-                getAbsentWorkerTasks(path);
+                getAbsentWorkerTasks(worker);
                 
                 break;
             case OK:

--- a/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
@@ -21,11 +21,8 @@ package org.apache.zookeeper.book;
 
 import java.util.ArrayList;
 
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.book.Client.TaskObject;
 import org.apache.zookeeper.book.Master.MasterStates;
-import org.apache.zookeeper.KeeperException.Code;
 
 import org.junit.Test;
 import org.junit.Assert;

--- a/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
@@ -289,34 +289,4 @@ public class TestTaskAssignment extends BaseTestCase {
         w3.close();
         c.close();
     }
-
-    /**
-     * A test class for mocking the Master that records the last worker for which
-     * getAbsentWorkerTasks was called.
-     */
-    class TestMaster extends Master {
-        String lastWorker;
-
-        TestMaster() {
-            super("localhost:" + port);
-        }
-
-        @Override
-        void getAbsentWorkerTasks(String worker) {
-            lastWorker = worker;
-        }
-    }
-
-    @Test
-    public void taskWorkerAssignmentCallback() throws Exception {
-        TestMaster m = new TestMaster();
-        m.startZK();
-        String testWorker = "worker-001";
-        m.workerAssignmentCallback.processResult(Code.CONNECTIONLOSS.intValue(),
-                "/assign/" + testWorker,
-                (Object) testWorker,
-                null);
-        m.close();
-        Assert.assertEquals("Last worker not matching", testWorker, m.lastWorker);
-    }
 }

--- a/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
@@ -21,8 +21,11 @@ package org.apache.zookeeper.book;
 
 import java.util.ArrayList;
 
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.book.Client.TaskObject;
 import org.apache.zookeeper.book.Master.MasterStates;
+import org.apache.zookeeper.KeeperException.Code;
 
 import org.junit.Test;
 import org.junit.Assert;
@@ -285,5 +288,57 @@ public class TestTaskAssignment extends BaseTestCase {
         w2.close();
         w3.close();
         c.close();
+    }
+
+    @Test(timeout=50000)
+    public void taskWorkerAssignmentCallback() throws Exception {
+        LOG.info("Starting master - Sequential");
+        Master m = new Master("localhost:" + port);
+        m.startZK();
+
+        while(!m.isConnected()){
+            Thread.sleep(500);
+        }
+
+        m.bootstrap();
+        m.runForMaster();
+
+        while(m.getState() == MasterStates.RUNNING){
+            Thread.sleep(100);
+        }
+
+        LOG.info("Starting worker");
+        Worker w = new Worker("localhost:" + port);
+        w.startZK();
+        while(!w.isConnected()){
+            Thread.sleep(100);
+        }
+
+        /*
+         * bootstrap() create some necessary znodes.
+         */
+        w.bootstrap();
+        /*
+         * Registers this worker so that the leader knows that
+         * it is here.
+         */
+        w.register();
+
+        LOG.info("Starting client");
+        Client c = new Client("localhost:" + port);
+        c.startZK();
+
+        while(!c.isConnected() &&
+                w.isConnected()){
+            Thread.sleep(100);
+        }
+
+        m.workerAssignmentCallback.processResult(Code.CONNECTIONLOSS.intValue(),
+                "/assign/" + w.name,
+                (Object) w.name,
+                null);
+
+        m.close();
+        w.close();
     }
 }

--- a/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
@@ -340,5 +340,6 @@ public class TestTaskAssignment extends BaseTestCase {
 
         m.close();
         w.close();
+        c.close();
     }
 }

--- a/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskAssignment.java
@@ -290,56 +290,33 @@ public class TestTaskAssignment extends BaseTestCase {
         c.close();
     }
 
-    @Test(timeout=50000)
+    /**
+     * A test class for mocking the Master that records the last worker for which
+     * getAbsentWorkerTasks was called.
+     */
+    class TestMaster extends Master {
+        String lastWorker;
+
+        TestMaster() {
+            super("localhost:" + port);
+        }
+
+        @Override
+        void getAbsentWorkerTasks(String worker) {
+            lastWorker = worker;
+        }
+    }
+
+    @Test
     public void taskWorkerAssignmentCallback() throws Exception {
-        LOG.info("Starting master - Sequential");
-        Master m = new Master("localhost:" + port);
+        TestMaster m = new TestMaster();
         m.startZK();
-
-        while(!m.isConnected()){
-            Thread.sleep(500);
-        }
-
-        m.bootstrap();
-        m.runForMaster();
-
-        while(m.getState() == MasterStates.RUNNING){
-            Thread.sleep(100);
-        }
-
-        LOG.info("Starting worker");
-        Worker w = new Worker("localhost:" + port);
-        w.startZK();
-        while(!w.isConnected()){
-            Thread.sleep(100);
-        }
-
-        /*
-         * bootstrap() create some necessary znodes.
-         */
-        w.bootstrap();
-        /*
-         * Registers this worker so that the leader knows that
-         * it is here.
-         */
-        w.register();
-
-        LOG.info("Starting client");
-        Client c = new Client("localhost:" + port);
-        c.startZK();
-
-        while(!c.isConnected() &&
-                w.isConnected()){
-            Thread.sleep(100);
-        }
-
+        String testWorker = "worker-001";
         m.workerAssignmentCallback.processResult(Code.CONNECTIONLOSS.intValue(),
-                "/assign/" + w.name,
-                (Object) w.name,
+                "/assign/" + testWorker,
+                (Object) testWorker,
                 null);
-
         m.close();
-        w.close();
-        c.close();
+        Assert.assertEquals("Last worker not matching", testWorker, m.lastWorker);
     }
 }

--- a/src/test/java/org/apache/zookeeper/book/TestTaskWorkerAssignmentCallback.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskWorkerAssignmentCallback.java
@@ -26,13 +26,13 @@ public class TestTaskWorkerAssignmentCallback {
     @Test
     public void taskWorkerAssignmentCallback() throws Exception {
         TestMaster m = new TestMaster();
-        m.startZK();
+        
         String testWorker = "worker-001";
         m.workerAssignmentCallback.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(),
                 "/assign/" + testWorker,
                 (Object) testWorker,
                 null);
-        m.close();
+
         Assert.assertEquals("Last worker not matching", testWorker, m.lastWorker);
     }
 }

--- a/src/test/java/org/apache/zookeeper/book/TestTaskWorkerAssignmentCallback.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskWorkerAssignmentCallback.java
@@ -12,7 +12,7 @@ class TestMaster extends Master {
     String lastWorker;
 
     TestMaster() {
-        super("localhost:2181");
+        super("IgnoredForTest");
     }
 
     @Override
@@ -26,11 +26,11 @@ public class TestTaskWorkerAssignmentCallback {
     @Test
     public void taskWorkerAssignmentCallback() throws Exception {
         TestMaster m = new TestMaster();
-        
+
         String testWorker = "worker-001";
         m.workerAssignmentCallback.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(),
                 "/assign/" + testWorker,
-                (Object) testWorker,
+                testWorker,
                 null);
 
         Assert.assertEquals("Last worker not matching", testWorker, m.lastWorker);

--- a/src/test/java/org/apache/zookeeper/book/TestTaskWorkerAssignmentCallback.java
+++ b/src/test/java/org/apache/zookeeper/book/TestTaskWorkerAssignmentCallback.java
@@ -1,0 +1,38 @@
+package org.apache.zookeeper.book;
+
+import org.apache.zookeeper.KeeperException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A test class for mocking the Master that records the last worker for which
+ * getAbsentWorkerTasks was called.
+ */
+class TestMaster extends Master {
+    String lastWorker;
+
+    TestMaster() {
+        super("localhost:2181");
+    }
+
+    @Override
+    void getAbsentWorkerTasks(String worker) {
+        lastWorker = worker;
+    }
+}
+
+public class TestTaskWorkerAssignmentCallback {
+
+    @Test
+    public void taskWorkerAssignmentCallback() throws Exception {
+        TestMaster m = new TestMaster();
+        m.startZK();
+        String testWorker = "worker-001";
+        m.workerAssignmentCallback.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(),
+                "/assign/" + testWorker,
+                (Object) testWorker,
+                null);
+        m.close();
+        Assert.assertEquals("Last worker not matching", testWorker, m.lastWorker);
+    }
+}


### PR DESCRIPTION
As described in issue #4 , there is a bug in the call to `getAbsentWorkerTasks` in `workerAssignmentCallback`. This PR fixes the issue and adds a test case. The test case reproduces the problem and validates that the change fixes it.

Closes #4 